### PR TITLE
Fix command handling for new mock insertion

### DIFF
--- a/tui/update.go
+++ b/tui/update.go
@@ -61,13 +61,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						delay:       m.formDelay,
 						jsonFile:    m.formJSONFile,
 					}
-					m.list.InsertItem(len(m.list.Items()), newItem)
+					cmd = tea.Batch(cmd, m.list.InsertItem(len(m.list.Items()), newItem))
 
 					// Reset
 					m.currentMode = listMode
 					m.formPath, m.formMethod, m.formStatus, m.formDelay, m.formJSONFile = "", "", "", "", ""
 					m.formStep = 0
-					return m, nil
+					return m, cmd
 				}
 			case tea.KeyBackspace:
 				// Permitir borrar carácter


### PR DESCRIPTION
## Summary
- return the command when inserting a new mock to keep list state updated

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688403803a748333aa67a0387012b64a