### PR TITLE
Add exit confirmation mode and improve code organization

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -7,8 +7,9 @@ import (
 type mode int
 
 const (
-	listMode mode = iota //0
-	formMode             //1
+	listMode        mode = iota //0
+	formMode                    //1
+	confirmExitMode             // nuevo modo para confirmar salida
 )
 
 type mockItem struct {

--- a/tui/update.go
+++ b/tui/update.go
@@ -35,12 +35,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case listMode:
 			switch msg.String() {
 			case "q", "ctrl+c":
-				return m, tea.Quit
+				// Cambiar al modo de confirmación de salida
+				m.currentMode = confirmExitMode
+				return m, nil
 			case "a":
 				m.currentMode = formMode
 				m.formStep = formStepPath
 				return m, nil
+			}
 
+		// CONFIRM EXIT MODE
+		case confirmExitMode:
+			switch msg.String() {
+			case "y", "Y":
+				// Confirmar salida
+				return m, tea.Quit
+			case "n", "N", "esc":
+				// Cancelar salida y volver al modo lista
+				m.currentMode = listMode
+				return m, nil
 			}
 
 		// FORM MODE


### PR DESCRIPTION
# Add exit confirmation mode

## Changes
- Added exit confirmation mode to prevent accidental exits
- Removed unused titleStyle variable from view.go
- Improved code organization and readability

## Testing Steps
1. Press `q` or `ctrl+c` in list mode - should show confirmation
2. Press `y` to confirm exit - should quit
3. Press `n` or `esc` to cancel - should return to list mode